### PR TITLE
clear content from configset: extrastaticroutes

### DIFF
--- a/azure_template_deployment/assets/configset/extrastaticroutes
+++ b/azure_template_deployment/assets/configset/extrastaticroutes
@@ -1,26 +1,4 @@
 
-config router static
-    edit 1
-        set dst 168.63.129.16 255.255.255.255
-        set gateway 10.0.1.1
-        set priority 5
-        set device "port2"
-    next
-    edit 2
-        set dst 168.63.129.16 255.255.255.255
-        set gateway 10.0.2.1
-        set priority 5
-        set device "port3"
-    next
-    edit 3
-        set dst 168.63.129.16 255.255.255.255
-        set gateway 10.0.3.1
-        set priority 5
-        set device "port4"
-    next
-    edit 4
-        set dst 168.63.129.16 255.255.255.255
-        set gateway 10.0.0.1
-        set device "port1"
-    next
-end
+# FortiGate only responds to Azure LB health check on port1 through default gateway.
+# You may need 'config router static' to set dns and gateway for extra ports.
+# See the official deployment guide for more information.


### PR DESCRIPTION
The removed content isn't necessary needed in general. It can cause issue if users used a non-default vnet address range (default is 10.0.0.0/16).
Now leave them to users for their own customization.

In addition, documentation update is also required for this change.