### PR TITLE
updates to versions, docs, and license in READMEs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 Fortinet Inc.
+Copyright 2021 Fortinet Inc.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The project also contains a deployment script that can generate packages for eac
 ## Deployment packages
 To generate local deployment packages:
 
-  1. From the [project release page](https://github.com/fortinet/fortigate-autoscale/releases), download the source code (.zip or .tar.gz) for the latest 2.0 version.
+  1. From the [project release page](https://github.com/fortinet/fortigate-autoscale/releases), download the source code (.zip or .tar.gz) for the latest 3.X version.
   2. Extract the source code.
   3. Run `npm run build` at the project root directory.
 
@@ -32,7 +32,7 @@ Deployment packages as well as source code will be available in the **dist** dir
 ## Deployment guide
 A deployment guide is available from the Fortinet Document Library:
 
-  + [ FortiGate / FortiOS 6.2 / Deploying auto scaling on Azure](https://docs.fortinet.com/vm/azure/fortigate/6.2/azure-cookbook/6.2.0/161167/deploying-auto-scaling-on-azure)
+  + [ FortiGate / FortiOS 6.4 / Deploying auto scaling on Azure](https://docs2.fortinet.com/vm/azure/fortigate/6.4/azure-cookbook/6.4.0/161167/deploying-auto-scaling-on-azure)
 
 ## Launch a demo
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Ffortinet%2Ffortigate-autoscale%2Fmaster%2Fazure_template_deployment%2Ftemplates%2Fdeploy_fortigate_autoscale.hybrid_licensing.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/></a>
@@ -41,7 +41,7 @@ A deployment guide is available from the Fortinet Document Library:
 ## Project development history
 | Version | Details | Documentation |
 | ------- | ------- | ------------- |
-| 3.0 (latest) | The AWS portion of this project has been moved to [fortigate-autoscale-aws](https://github.com/fortinet/fortigate-autoscale-aws). Going forward, this project will be maintained for Azure only. | [ FortiGate / FortiOS 6.2 / Deploying auto scaling on Azure](https://docs.fortinet.com/vm/azure/fortigate/6.2/azure-cookbook/6.2.0/161167/deploying-auto-scaling-on-azure) |
+| 3.0 (latest) | The AWS portion of this project has been moved to [fortigate-autoscale-aws](https://github.com/fortinet/fortigate-autoscale-aws). Going forward, this project will be maintained for Azure only. | [ FortiGate / FortiOS 6.4 / Deploying auto scaling on Azure](https://docs2.fortinet.com/vm/azure/fortigate/6.4/azure-cookbook/6.4.0/161167/deploying-auto-scaling-on-azure) |
 | 2.0 | Added support for Hybrid Licensing (any combination of BYOL and/or PAYG instances). | A PDF for AWS is available in the 2.0 branch.<br/>[deploying-auto-scaling-on-aws-2.0.9.pdf](https://github.com/fortinet/fortigate-autoscale/blob/2.0/docs/deploying-auto-scaling-on-aws-2.0.9.pdf) |
 | 1.0 | Supports auto scaling for PAYG instances only.  | PDFs for AWS and for Azure are available in the 1.0.6 branch.<br/>[deploying-auto-scaling-on-aws-1.0.pdf](https://github.com/fortinet/fortigate-autoscale/blob/1.0/docs/deploying-auto-scaling-on-aws-1.0.pdf)<br/>[deploying-auto-scaling-on-azure-1.0.pdf](https://github.com/fortinet/fortigate-autoscale/blob/1.0/docs/deploying-auto-scaling-on-azure-1.0.pdf) |
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -1,7 +1,7 @@
 # FortiGate Autoscale for Azure
 This is the FortiGate Autoscale module for the Azure Cloud Platform.
 
-For more information, please refer to the project [README](https://github.com/fortinet/fortigate-autoscale/blob/master/README.md).
+For more information, please refer to the project [README](https://github.com/fortinet/fortigate-autoscale/blob/main/README.md).
 
 # Support
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
@@ -9,4 +9,4 @@ For direct issues, please refer to the [Issues](https://github.com/fortinet/fort
 For other questions related to this project, contact [github@fortinet.com](mailto:github@fortinet.com).
 
 ## License
-[License](https://github.com/fortinet/fortigate-autoscale/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.
+[License](https://github.com/fortinet/fortigate-autoscale/blob/main/LICENSE) © Fortinet Technologies. All rights reserved.

--- a/azure_funcapp/README.md
+++ b/azure_funcapp/README.md
@@ -4,7 +4,7 @@ This folder contains source code for the FortiGate Autoscale handler for the Azu
 ## Deployment Package
 To generate a deployment package, go to the root directory of the FortiGate Autoscale project and run `npm run build-azure-funcapp`.
 
-For more information, please refer to the project [README](https://github.com/fortinet/fortigate-autoscale/blob/master/README.md).
+For more information, please refer to the project [README](https://github.com/fortinet/fortigate-autoscale/blob/main/README.md).
 
 # Support
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
@@ -12,4 +12,4 @@ For direct issues, please refer to the [Issues](https://github.com/fortinet/fort
 For other questions related to this project, contact [github@fortinet.com](mailto:github@fortinet.com).
 
 ## License
-[License](https://github.com/fortinet/fortigate-autoscale/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.
+[License](https://github.com/fortinet/fortigate-autoscale/blob/main/LICENSE) © Fortinet Technologies. All rights reserved.

--- a/azure_template_deployment/README.md
+++ b/azure_template_deployment/README.md
@@ -6,7 +6,7 @@ The button below can be used to start the deployment.
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Ffortinet%2Ffortigate-autoscale%2Fmaster%2Fazure_template_deployment%2Ftemplates%2Fdeploy_fortigate_autoscale.hybrid_licensing.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/></a>
 
-For details regarding parameters as well as activities that must occur before and after deploying the template, refer to the relevant Installation Guide listed in the project [README](https://github.com/fortinet/fortigate-autoscale/blob/master/README.md).
+For details regarding parameters as well as activities that must occur before and after deploying the template, refer to the relevant Installation Guide listed in the project [README](https://github.com/fortinet/fortigate-autoscale/blob/main/README.md).
 
 # Support
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
@@ -14,4 +14,4 @@ For direct issues, please refer to the [Issues](https://github.com/fortinet/fort
 For other questions related to this project, contact [github@fortinet.com](mailto:github@fortinet.com).
 
 ## License
-[License](https://github.com/fortinet/fortigate-autoscale/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.
+[License](https://github.com/fortinet/fortigate-autoscale/blob/main/LICENSE) © Fortinet Technologies. All rights reserved.

--- a/core/README.md
+++ b/core/README.md
@@ -10,7 +10,7 @@ The design metaphor for `fortigate-autoscale/core` is an API sandwich with cloud
 
 There is also a container class `LifecycleItem` which is currently used only by AWS. This class serves as a common container for Lifecycle event data.
 
-For more information, please refer to the project [README](https://github.com/fortinet/fortigate-autoscale/blob/master/README.md).
+For more information, please refer to the project [README](https://github.com/fortinet/fortigate-autoscale/blob/main/README.md).
 
 # Support
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.


### PR DESCRIPTION
Main README referenced release 2.0 and pointed to 6.2 docs.

License update to 2021

READMEs in subdirectories pointed to README.md and LICENSE in master branch not main branch