### PR TITLE
clear comments from configset file extrastaticroutes

### DIFF
--- a/azure_template_deployment/assets/configset/extrastaticroutes
+++ b/azure_template_deployment/assets/configset/extrastaticroutes
@@ -1,4 +1,0 @@
-
-# FortiGate only responds to Azure LB health check on port1 through default gateway.
-# You may need 'config router static' to set dns and gateway for extra ports.
-# See the official deployment guide for more information.


### PR DESCRIPTION
remove the comments content from the configest file since they aren't helpful to be placed there.