### PR TITLE
increase primary election timeout to 300

### DIFF
--- a/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.params.json
+++ b/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.params.json
@@ -102,7 +102,7 @@
             "value": 20
         },
         "PrimaryElectionTimeout": {
-            "value": 90
+            "value": 300
         },
         "GetLicenseGracePeriod": {
             "value": 600

--- a/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.stage01.json
+++ b/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.stage01.json
@@ -252,7 +252,7 @@
             }
         },
         "PrimaryElectionTimeout": {
-            "defaultValue": 90,
+            "defaultValue": 300,
             "type": "Int",
             "metadata": {
                 "description": "The maximum time (in seconds) to wait for a primary election to complete."

--- a/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.stage02.json
+++ b/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.stage02.json
@@ -252,7 +252,7 @@
             }
         },
         "PrimaryElectionTimeout": {
-            "defaultValue": 90,
+            "defaultValue": 300,
             "type": "Int",
             "metadata": {
                 "description": "The maximum time (in seconds) to wait for a primary election to complete."


### PR DESCRIPTION
increase template parameter primary election timeout default value from 90 to 300

The current fgt vm requires longer time than before to send the 1st heartbeat to the function.
It may highly likely exceed the current primary election time out time so we need to increase the time out.

Since the template already has a parameter to set the primary election timeout time, it gives a default 90 seconds which isn't enough.

update the template parameter default value from 90 to 300