### PR TITLE
Doc update 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2021-01-29
+
+### Added
+
+- Added support for FOS 6.4.3
+- Enhanced build script on version bump to update template content version and Azure function package version to match the version of the project
+
+### Changed
+
+- Removed FOS 6.2.5 from support list
+- Fixed inconsistent static route configuration if deployed notusing default vnet IP address values.
+- Changed the default value of the template parameter 'primary election timeout' from 90 to 300.
+
+
 ## [3.1.0] - 2020-12-07
 
 ### Added

--- a/azure_funcapp/package.json
+++ b/azure_funcapp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fortigate-autoscale-azure-funcapp",
-    "version": "3.0.0",
+    "version": "3.1.1",
     "description": "FortiGate Autoscale Project - Azure Function App",
     "main": "index.js",
     "scripts": {

--- a/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.params.json
+++ b/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.params.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.11",
+    "contentVersion": "3.1.1.0",
     "parameters": {
         "ResourceNamePrefix": {
             "value": ""

--- a/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.stage01.json
+++ b/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.stage01.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.12",
+    "contentVersion": "3.1.1.0",
     "parameters": {
         "ResourceNamePrefix": {
             "maxLength": 10,

--- a/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.stage02.json
+++ b/azure_template_deployment/templates/deploy_fortigate_autoscale.hybrid_licensing.stage02.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.12",
+    "contentVersion": "3.1.1.0",
     "parameters": {
         "ResourceNamePrefix": {
             "maxLength": 10,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "fortigate-autoscale",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fortigate-autoscale",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "FortiGate Autoscale Project",
     "main": "index.js",
     "directories": {


### PR DESCRIPTION
This PR is to collect documentation related changes for the incoming release to tag in the main branch.

the next release version is 3.1.1

Additionally, the year on the LICENSE needs to update to 2021 too.